### PR TITLE
cleaned up issue related to bootstrap.  updated associated fragments

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -4,12 +4,22 @@
     <meta charset="UTF-8"/>
     <title>Resoled</title>
 
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"/>
+<!--    Below is part of Bootstrap-->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+
+<!--    Now our style.css sheet-->
     <link rel="stylesheet" th:href="@{/css/styles.css}"/>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
 
 </head>
 <body>
+
+
+
+<!--The script below is for Bootstrap-->
+<th:block th:fragment="endingScripts">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+</th:block>
+
 
 </body>
 </html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -36,8 +36,11 @@ TEST HOME
 <a href="/image/imageUploadPlaceholder">Image upload placeholder Page</a></br>
 <a href="/search">Search Page</a>
 
-<p>Potential Color Pallets up for reflection</p>
 
+<br/>
+<br/>
+<p>Potential Color Pallet up for review:</p>
+<br/>
 <div class="color1 border rounded">
    <br/>
     <br/>
@@ -64,5 +67,6 @@ TEST HOME
     <br/>
 </div>
 
+<th:block th:replace="~{fragments :: endingScripts}"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -42,6 +42,7 @@
         </div>
     </div>
 </div>
+<th:block th:replace="~{fragments :: endingScripts}"></th:block>
 
 </body>
 </html>

--- a/src/main/resources/templates/message/create.html
+++ b/src/main/resources/templates/message/create.html
@@ -38,5 +38,7 @@
 
 </form>
 
+
+<th:block th:replace="~{fragments :: endingScripts}"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/message/message.html
+++ b/src/main/resources/templates/message/message.html
@@ -57,6 +57,6 @@
 
 <a href="/message/messages">Return to MessageChain page</a>
 
-<!--will hold a single message chain with a list of the chain's messages as well as a form to add a message.-->
+<th:block th:replace="~{fragments :: endingScripts}"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/message/messages.html
+++ b/src/main/resources/templates/message/messages.html
@@ -47,5 +47,6 @@
 </div>
 
 
-
-</body></html>
+<th:block th:replace="~{fragments :: endingScripts}"></th:block>
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -74,5 +74,7 @@
     </div>
 </div>
 
+<th:block th:replace="~{fragments :: endingScripts}"></th:block>
+
 </body>
 </html>


### PR DESCRIPTION
There are fragments available to add styling to your page.  There is a <head> fragment (named "head")to replace the template <head> and a <th:block> fragment (named "endingScripts" )that should be kept at the bottom of the <body> tag right before the </body>  the <th:block> fragment is for the <script> for bootstrap.